### PR TITLE
Avoid 400 status error from Stripe

### DIFF
--- a/resources/views/billing/checkout.blade.php
+++ b/resources/views/billing/checkout.blade.php
@@ -175,6 +175,15 @@
           }).done(function(result) {
             if (result.error_text) {
               $('#coupon-text').text(result.error_text);
+              let plan_paying_amount = parseFloat($('#plan-paying-amount').val());
+              let tax_percent = $('#tax-percent').val();
+              let pay_amount = plan_paying_amount;
+              $('#amount_subtotal').text('$' + pay_amount);
+              let tax_amount = (pay_amount * tax_percent / 100).toFixed(2);
+              $('#amount_taxes').text('$' + tax_amount);
+              pay_amount = (parseFloat(pay_amount) + parseFloat(tax_amount)).toFixed(2);
+              $('#amount_total').text('$' + pay_amount);
+              $('#card-button').text('Pay $' + pay_amount);
             } else {
               $('#coupon-text').text(result.name);
               let plan_paying_amount = parseFloat($('#plan-paying-amount').val());

--- a/resources/views/billing/checkout.blade.php
+++ b/resources/views/billing/checkout.blade.php
@@ -141,12 +141,16 @@
           if (paymentMethod) {
             return true
           }
+          var card_holder_name = $('#card-holder-name').val();
+          if (card_holder_name == null || card_holder_name == "" || card_holder_name == undefined) {
+            return false
+          }
           stripe.confirmCardSetup(
             "{{ $intent->client_secret }}",
             {
               payment_method: {
                 card: card,
-                billing_details: {name: $('#card-holder-name').val()}
+                billing_details: {name: card_holder_name }
               }
             }
           ).then(function (result) {

--- a/resources/views/payment-methods/create.blade.php
+++ b/resources/views/payment-methods/create.blade.php
@@ -72,12 +72,16 @@
           if (paymentMethod) {
             return true
           }
+          var card_holder_name = $('#card-holder-name').val();
+          if (card_holder_name == null || card_holder_name == "" || card_holder_name == undefined) {
+            return false
+          }
           stripe.confirmCardSetup(
             "{{ $intent->client_secret }}",
             {
               payment_method: {
                 card: card,
-                billing_details: {name: $('#card-holder-name').val()}
+                billing_details: {name: card_holder_name }
               }
             }
           ).then(function (result) {


### PR DESCRIPTION
Before we execute the Post request to Stripe, we can ensure that the value of card-holder-name is not empty, otherwise, it will return a "parameter_invalid_empty" error.